### PR TITLE
Add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,4 +59,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/dazz/Parser.java
+++ b/src/main/java/dazz/Parser.java
@@ -62,6 +62,7 @@ public class Parser {
         } else if (arr[1].trim().equals("")) {
             throw new EmptyDescriptionException();
         }
+        assert !arr[1].equals("");
         return new TodoCommand(arr[1]);
     }
 
@@ -100,6 +101,7 @@ public class Parser {
         } else if (arr[1].trim().equals("")) {
             throw new IncompleteCommandException();
         }
+        assert !arr[1].equals("");
         return new FindCommand(arr[1]);
     }
 
@@ -110,6 +112,7 @@ public class Parser {
         } else if (arr[1].trim().equals("")) {
             throw new IncompleteCommandException();
         }
+        assert !arr[1].equals("");
         return new MarkCommand(Integer.parseInt(arr[1]));
     }
 
@@ -120,6 +123,7 @@ public class Parser {
         } else if (arr[1].trim().equals("")) {
             throw new IncompleteCommandException();
         }
+        assert !arr[1].equals("");
         return new UnmarkCommand(Integer.parseInt(arr[1]));
 
     }
@@ -131,6 +135,7 @@ public class Parser {
         } else if (arr[1].trim().equals("")) {
             throw new IncompleteCommandException();
         }
+        assert !arr[1].equals("");
         return new DeleteCommand(Integer.parseInt(arr[1]));
     }
 }

--- a/src/main/java/dazz/Storage.java
+++ b/src/main/java/dazz/Storage.java
@@ -36,6 +36,7 @@ public class Storage {
             }
             this.file = new File("data/tasks.txt");
             this.file.createNewFile();
+            assert file.exists();
         } catch (FileAlreadyExistsException e) {
             e.getStackTrace();
         } catch (IOException e) {


### PR DESCRIPTION
Modify build.gradle to allow assertions.

Assertion is added to storage as we need to ensure that the
txt file is created in order to store tasks in it.

Commands like mark, unmark, todo, delete and find are based
on single description (i.e integer/string), so we need to
make sure that it is non-empty description is passed.